### PR TITLE
feat: Add toggle for day of week display and bump version

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -14,6 +14,9 @@
     "toggleDateText": {
         "message": "Toggle Date"
     },
+    "toggleDayOfWeekText": {
+        "message": "Toggle Day Name"
+    },
     "toggleNotepadText": {
         "message": "Toggle Notepad"
     },

--- a/clock_window.html
+++ b/clock_window.html
@@ -29,6 +29,7 @@
                 <button id="toggle-seconden"></button>
                 <button id="toggle-notepad"></button>
                 <button id="toggle-datum"></button>
+                <button id="toggle-dag-naam"></button>
                 <button id="toggle-batterij"></button>
             </div>
             <button id="start-screensaver" class="screensaver-knop-in-paneel"></button>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "icons": {


### PR DESCRIPTION
- Adds a new button to the settings panel to toggle the visibility of the day of the week in the date string.
- The setting is persisted in local storage.
- Bumps the extension version from 1.3.3 to 1.4.0 in manifest.json.